### PR TITLE
Remove ansys-dpf-gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "ansys-dpf-composites==0.4.0",
     "ansys-dpf-core==0.12.0",
     "ansys-dpf-post==0.8.0",
-    "ansys-dpf-gate==0.4.1",
     "ansys-dyna-core==0.4.15",
     "ansys-dynamicreporting-core==0.6.0",
     "ansys-edb-core==0.1.4",


### PR DESCRIPTION
Hi everyone,

not sure why it is still there, but users have reported PyDPF errors while installing via the pyansys package, and indeed since ansys-dpf-core 0.10.0 the dependency ansys-dpf-gate is not a dependency anymore and should even NOT be present, otherwise we have problems.
Is it possible to release a patch?
I'll have to check which versions are impacted.

Problem seen in:
[v2024.1.7](https://github.com/ansys/pyansys/releases/tag/v2024.1.7)
Starts with:
[v2024.1.0](https://github.com/ansys/pyansys/releases/tag/v2024.1.0)

So I guess a release of 2024.1.8 would be enough.