### PR TITLE
Update PyGranta to 2024.2.0

### DIFF
--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         pyansys-projects:
           [
-            "ansys/openapi-common",
             "ansys/pyacp",
             "ansys/pyadditive",
             "ansys/pyadditive-widgets",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
     "ansys-meshing-prime==0.6.0.dev9",
     "ansys-modelcenter-workflow==0.1.1",
     "ansys-motorcad-core==0.5.0",
-    "ansys-openapi-common==1.5.1",
     "ansys-optislang-core==0.7.1",
     "ansys-platform-instancemanagement==1.1.2",
     "ansys-pyensight-core==0.8.1",
@@ -58,7 +57,7 @@ dependencies = [
     "ansys-turbogrid-core==0.4.1",
     "pyaedt==0.9.3",
     "pyedb==0.13.0",
-    "pygranta==2024.1.0",
+    "pygranta==2024.2.0",
     "pytwin==0.7.0",
 ]
 

--- a/tools/links.py
+++ b/tools/links.py
@@ -41,7 +41,7 @@ LINKS = {
     "ansys-meshing-prime": "https://prime.docs.pyansys.com/version/stable",
     "ansys-modelcenter-workflow": "https://modelcenter.docs.pyansys.com/version/stable",  # noqa: E501
     "ansys-motorcad-core": "https://motorcad.docs.pyansys.com/version/stable",
-    "ansys-openapi-common": "https://openapi.docs.pyansys.com/version/stable",
+    "ansys-openapi-common": None,
     "ansys-optislang-core": "https://optislang.docs.pyansys.com/version/stable",
     "ansys-platform-instancemanagement": "https://pypim.docs.pyansys.com/version/stable",  # noqa: E501
     "ansys-pyensight-core": "https://ensight.docs.pyansys.com/version/stable",


### PR DESCRIPTION
Update PyGranta to 2024.2.0. This will need to be cherry-picked onto the 2024.2 release branch before release.

Also remove dependency on ansys-openapi-common, since in my opinion this is an unneeded constraint. I think currently only PyGranta packages include this, and if any other packages include it, they should declare it as a dependency themselves.

@klmcadams Adding you as a reviewer since you were suggested by GitHub.