### PR TITLE
fix: ansys-fluent-core version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "ansys-dyna-core==0.4.15",
     "ansys-dynamicreporting-core==0.6.0",
     "ansys-edb-core==0.1.4",
-    "ansys-fluent-core==0.21.1",
+    "ansys-fluent-core==0.21.0",
     "ansys-geometry-core==0.6.5",
     "ansys-hps-client==0.8.0",
     "ansys-mapdl-core==0.68.3",


### PR DESCRIPTION
ansys-fluent-core 0.21.1 does not exist, set the version to 0.21.0