### PR TITLE
feat: dropping support for Python 3.9  and upgrade to v2025.1.dev0

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
         extras-version: ['fluent-all', 'mapdl-all', 'tools']
 
     steps:
@@ -123,7 +123,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - name: Build wheelhouse and perform smoke test
@@ -217,7 +217,7 @@ jobs:
         uses: ansys/actions/release-github@v6
         with:
           library-name: ${{ env.PACKAGE_NAME }}
-          additional-artifacts: 'all-deps-Linux-3.9 all-deps-Linux-3.10 all-deps-Linux-3.11 all-deps-Linux-3.12 all-deps-Windows-3.9 all-deps-Windows-3.10 all-deps-Windows-3.11 all-deps-Windows-3.12 all-deps-macOS-3.9 all-deps-macOS-3.10 all-deps-macOS-3.11 all-deps-macOS-3.12'
+          additional-artifacts: 'all-deps-Linux-3.10 all-deps-Linux-3.11 all-deps-Linux-3.12 all-deps-Windows-3.10 all-deps-Windows-3.11 all-deps-Windows-3.12 all-deps-macOS-3.10 all-deps-macOS-3.11 all-deps-macOS-3.12'
 
   docs-release:
     name: Deploy release docs

--- a/README.rst
+++ b/README.rst
@@ -188,18 +188,18 @@ the ``pyansys`` metapackage is downloading the wheelhouse archive from the
 `Releases Page <https://github.com/ansys/pyansys/releases>`_ for your corresponding machine architecture.
 
 Each wheelhouse archive contains all the Python wheels necessary to install the ``pyansys`` metapackage from
-scratch on Windows, Linux, and MacOS from Python 3.9 to 3.11. You can install this on an isolated system with
+scratch on Windows, Linux, and MacOS from Python 3.10 to 3.12. You can install this on an isolated system with
 a fresh Python installation or on a virtual environment.
 
-For example, on Linux with Python 3.9, unzip the wheelhouse archive and install it with the following
+For example, on Linux with Python 3.10, unzip the wheelhouse archive and install it with the following
 commands:
 
 .. code:: bash
 
-    unzip pyansys-v2024.2.dev0-wheelhouse-Linux-3.9-core.zip wheelhouse
+    unzip pyansys-v2025.1.dev0-wheelhouse-Linux-3.10-core.zip wheelhouse
     pip install pyansys -f wheelhouse --no-index --upgrade --ignore-installed
 
-If you're on Windows with Python 3.9, unzip to a wheelhouse directory and then install using
+If you're on Windows with Python 3.10, unzip to a wheelhouse directory and then install using
 the same ``pip`` command as in the previous example.
 
 Consider installing using a `virtual environment <https://docs.python.org/3/library/venv.html>`_.

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -79,18 +79,18 @@ corresponding machine architecture.
 
 Each wheelhouse archive contains all the Python wheels necessary to install
 ``pyansys`` metapackage from scratch on Windows, Linux, and MacOS from Python
-3.9 to 3.11. You can install this on an isolated system with a fresh Python
+3.10 to 3.12. You can install this on an isolated system with a fresh Python
 installation or on a virtual environment.
 
-For example, on Linux with Python 3.9, unzip the wheelhouse archive and install
+For example, on Linux with Python 3.10, unzip the wheelhouse archive and install
 it with the following:
 
 .. code:: bash
 
-    unzip pyansys-v2024.2.dev0-wheelhouse-Linux-3.9-core.zip wheelhouse
+    unzip pyansys-v2025.1.dev0-wheelhouse-Linux-3.10-core.zip wheelhouse
     pip install pyansys -f wheelhouse --no-index --upgrade --ignore-installed
 
-If you're on Windows with Python 3.9, unzip to a wheelhouse directory and install using the same command as above.
+If you're on Windows with Python 3.10, unzip to a wheelhouse directory and install using the same command as above.
 
 Consider installing using a `virtual environment <venv_docs_>`_.
 

--- a/doc/source/supported_versions.rst
+++ b/doc/source/supported_versions.rst
@@ -17,6 +17,11 @@ differ from the SPEC-0 policy but is always aligned with it.
 * Light blue Python versions are currently supported.
 * Dark blue Python versions are upcoming Python releases for which support is expected in the future.
 
+Some extra remarks:
+
+* The length of the Python version boxes is indicative of the support duration according to the SPEC-0 policy.
+* The color of the Python version boxes is indicative of the PyAnsys metapackage current support.
+
 .. mermaid::
    :caption: Python versions supported by SPEC-0 policy (red line) and PyAnsys Python versions supported (color coded)
    :alt: Python versions supported by SPEC-0 policy (red line) and PyAnsys Python versions supported (color coded)
@@ -27,7 +32,7 @@ differ from the SPEC-0 policy but is always aligned with it.
         axisFormat %Y-%m
         Python 3.7  :done,   des1, 2018-06-27, 3y
         Python 3.8  :done,   des2, 2019-10-14, 3y
-        Python 3.9  :active, des3, 2020-10-05, 3y
+        Python 3.9  :done,   des3, 2020-10-05, 3y
         Python 3.10 :active, des4, 2021-10-04, 3y
         Python 3.11 :active, des5, 2022-10-24, 3y
         Python 3.12 :active, des6, 2023-10-02, 3y
@@ -46,7 +51,7 @@ Below you can find a list of the Python versions supported by each PyAnsys metap
 +-----------------+----------------------------+
 | `2024.2`_       | Python 3.9 - Python 3.12   |
 +-----------------+----------------------------+
-| `development`_  | Python 3.9 - Python 3.12   |
+| `development`_  | Python 3.10 - Python 3.12  |
 +-----------------+----------------------------+
 
 
@@ -56,5 +61,5 @@ Below you can find a list of the Python versions supported by each PyAnsys metap
 .. _2023.1: https://pypi.org/project/pyansys/2023.1.3/
 .. _2023.2: https://pypi.org/project/pyansys/2023.2.11/
 .. _2024.1: https://pypi.org/project/pyansys/2024.1.8/
-.. _2024.2: https://pypi.org/project/pyansys/2024.2.0b2/
+.. _2024.2: https://pypi.org/project/pyansys/2024.2.2/
 .. _development: https://github.com/ansys/pyansys

--- a/doc/source/supported_versions.rst
+++ b/doc/source/supported_versions.rst
@@ -19,7 +19,7 @@ differ from the SPEC-0 policy but is always aligned with it.
 
 Some extra remarks:
 
-* The length of the Python version boxes is indicative of the support duration according to the SPEC-0 policy.
+* The length of the Python version boxes is indicative of the support duration according to the `SPEC-0`_ policy.
 * The color of the Python version boxes is indicative of the PyAnsys metapackage current support.
 
 .. mermaid::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,10 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "pyansys"
-version = "2024.2.dev0"
+version = "2025.1.dev0"
 description = "Pythonic interfaces to Ansys products"
 readme = "README.rst"
-requires-python = ">=3.9,<4"
+requires-python = ">=3.10,<4"
 license = { file = "LICENSE" }
 authors = [{ name = "ANSYS, Inc.", email = "pyansys.support@ansys.com" }]
 maintainers = [{ name = "PyAnsys developers", email = "pyansys.maintainers@ansys.com" }]
@@ -18,7 +18,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
As title says. Following SPEC-0000 and our internal ADR - we should drop support for Python 3.9. This was informed in the dev meeting. We will reiterate this in a few weeks to the rest of the ecosystem.