### PR TITLE
feat: udpate pyworkbench to v0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "ansys-sound-core==0.1.3",
     "ansys-systemcoupling-core==0.6.0",
     "ansys-turbogrid-core==0.4.1",
-    "ansys-workbench-core==0.4.0",
+    "ansys-workbench-core==0.5.0",
     "pyaedt==0.9.11",
     "pyedb==0.23.0",
     "pygranta==2024.2.0",


### PR DESCRIPTION
Update `ansys-core-workbench` to version v0.5.