### PR TITLE
feat: listing PyAnsys metapackage versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ instance/
 doc/_build/
 doc/**/_autosummary
 doc/source/examples/*
+doc/source/tmp_pyproject.toml
 
 # PyBuilder
 .pybuilder/

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -97,6 +97,7 @@ with open("links.rst") as f:
 linkcheck_ignore = [
     r"https://www.ansys.com/.*",
     rf"https://pypi.org/project/pyansys/{switcher_version}.*",
+    r"https://ansunits.docs./*",
 ]
 
 # User agent

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -97,7 +97,7 @@ with open("links.rst") as f:
 linkcheck_ignore = [
     r"https://www.ansys.com/.*",
     rf"https://pypi.org/project/pyansys/{switcher_version}.*",
-    r"https://ansunits.docs./*",
+    r"https://ansunits.docs.*",
 ]
 
 # User agent

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -122,7 +122,7 @@ def generate_rst_files(versions: list[str], tables: dict[str, list[str]]):
 
     GENERATED_DIR = Path(__file__).parent / "package_versions"
 
-    TEMPLATE_VERSIONS = """
+    VERSIONS_TEMPLATE = """
 Package versions in PyAnsys {{ version }}
 ============================{{ "=" * version|length }}
 
@@ -153,14 +153,14 @@ metapackage release.
     jinja_env = jinja2.Environment(loader=jinja2.BaseLoader())
 
     # Compile the template
-    template = jinja_env.from_string(TEMPLATE_VERSIONS)
+    template = jinja_env.from_string(VERSIONS_TEMPLATE)
 
     # Generate an .rst file for each version entry
-    for version, table_key in zip(versions, tables):
+    for version in versions:
         # Generate the content of the .rst file using the Jinja template
         rendered_content = template.render(
             version=version,
-            table=tables[table_key],
+            table=tables[version],
         )
 
         # Define the output path for the generated file
@@ -172,9 +172,7 @@ metapackage release.
 
     # Generate the index.rst file
     index_template = jinja_env.from_string(INDEX_TEMPLATE)
-    rendered_index = index_template.render(
-        versions=versions,
-    )
+    rendered_index = index_template.render(versions=versions)
 
     # Write the rendered content to the file
     output_filename = GENERATED_DIR / "index.rst"
@@ -182,7 +180,7 @@ metapackage release.
         f.write(rendered_index)
 
 
-def build_versions_table(branch: str = "main") -> list[str]:
+def build_versions_table(branch: str) -> list[str]:
     """Build the versions table for the PyAnsys libraries."""
     import requests
     import toml
@@ -275,13 +273,12 @@ def get_release_branches_in_metapackage():
             release_branches.append(branch.name)
             versions.append(branch.name.split("/")[-1])
 
-    # Sort the release branches and versions: main + from newest to oldest
+    # Sort the release branches and versions: from newest to oldest
     release_branches.reverse()
     versions.reverse()
-    release_branches = ["main"] + release_branches
-    versions = ["dev"] + versions
 
-    return release_branches, versions
+    # Return the dev/main branch and the release branches (and versions)
+    return ["main"] + release_branches, ["dev"] + versions
 
 
 # -------------------------------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -101,3 +101,197 @@ linkcheck_ignore = [
 
 # User agent
 user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36 Edg/123.0.2420.81"  # noqa: E501
+
+
+###########################################################################
+# Generate the package_versions directory
+###########################################################################
+# This section generates the package_versions directory in the doc/source
+# directory. This directory contains the .rst files that list the PyAnsys
+# package versions available in the various PyAnsys metapackages releases.
+#
+# The script retrieves the PyAnsys package versions from the pyproject.toml
+# file for the minor versions of the PyAnsys metapackage release branches.
+
+
+def generate_rst_files(versions: list[str], tables: dict[str, list[str]]):
+    """Generate the .rst files for the package versions."""
+    from pathlib import Path
+
+    import jinja2
+
+    GENERATED_DIR = Path(__file__).parent / "package_versions"
+
+    TEMPLATE_VERSIONS = """
+Package versions in PyAnsys {{ version }}
+============================{{ "=" * version|length }}
+
+The PyAnsys packages delivered in version {{ version }} are:
+{{ ' ' }}
+{%- for entry in table %}
+{{ entry }}
+{%- endfor %}
+"""
+
+    INDEX_TEMPLATE = """
+Package versions
+================
+
+Users can find below the list of PyAnsys packages available in the various
+PyAnsys metapackages. The tables shows the package versions available in each
+metapackage release.
+
+.. toctree::
+   :maxdepth: 3
+   {{ ' ' }}
+   {%- for version in versions %}
+   version_{{ version }}
+   {%- endfor %}
+"""
+
+    # Create Jinja2 environment
+    jinja_env = jinja2.Environment(loader=jinja2.BaseLoader())
+
+    # Compile the template
+    template = jinja_env.from_string(TEMPLATE_VERSIONS)
+
+    # Generate an .rst file for each version entry
+    for version, table_key in zip(versions, tables):
+        # Generate the content of the .rst file using the Jinja template
+        rendered_content = template.render(
+            version=version,
+            table=tables[table_key],
+        )
+
+        # Define the output path for the generated file
+        output_filename = GENERATED_DIR / f"version_{version}.rst"
+
+        # Write the rendered content to the file
+        with open(output_filename, "w") as f:
+            f.write(rendered_content)
+
+    # Generate the index.rst file
+    index_template = jinja_env.from_string(INDEX_TEMPLATE)
+    rendered_index = index_template.render(
+        versions=versions,
+    )
+
+    # Write the rendered content to the file
+    output_filename = GENERATED_DIR / "index.rst"
+    with open(output_filename, "w") as f:
+        f.write(rendered_index)
+
+
+def build_versions_table(branch: str = "main") -> list[str]:
+    """Build the versions table for the PyAnsys libraries."""
+    import requests
+    import toml
+
+    TMP_FILE = "tmp_pyproject.toml"
+
+    # Download the pyproject.toml file
+    resp = requests.get(f"https://raw.githubusercontent.com/ansys/pyansys/{branch}/pyproject.toml")
+    with open("tmp_pyproject.toml", "wb") as f:
+        f.write(resp.content)
+
+    # Load the pyproject.toml file using TOML parser
+    pyproject_toml = toml.load(TMP_FILE)
+
+    # Check if it is poetrty based or flit based and
+    # load the PyAnsys library versions
+    list_pyansys_libraries: list[str] = []
+    if "poetry" in pyproject_toml["tool"]:  # Assume poetry
+        for key, val in pyproject_toml["tool"]["poetry"]["dependencies"].items():
+            # Ignore some libraries
+            if key in ["python", "importlib-metadata", "Sphinx"]:
+                continue
+
+            # Check if the version is a string or a dictionary...
+            if (
+                isinstance(val, dict)
+                and isinstance(val["version"], str)
+                and val["version"].startswith("==")
+            ):
+                list_pyansys_libraries.append(f"{key}{val['version']}")
+            elif isinstance(val, str) and val.startswith("=="):
+                list_pyansys_libraries.append(f"{key}{val}")
+            else:
+                continue
+    else:  # Assume flit
+        list_pyansys_libraries += pyproject_toml["project"]["dependencies"]
+        list_pyansys_libraries += pyproject_toml["project"]["optional-dependencies"]["all"]
+
+        # Ignore some libraries: in this case, only importlib-metadata
+        list_pyansys_libraries = [
+            entry for entry in list_pyansys_libraries if not entry.startswith("importlib-metadata")
+        ]
+
+    # Delete the temporary file
+    os.remove(TMP_FILE)
+
+    # Build the table
+    table = []
+
+    # Add the header
+    dict_table_entries: dict[str, str] = {}
+    for entry in list_pyansys_libraries:
+        library, version = entry.split("==")
+        pypi_link = f"https://pypi.org/project/{library}/{version}"
+        dict_table_entries[library] = f"`{version} <{pypi_link}>`__"
+
+    # Get the max length of the library names and links
+    max_length_key = max(len(library) for library in dict_table_entries.keys())
+    max_length_value = max(len(link) for link in dict_table_entries.values())
+
+    # Format the table entries and headers
+    table = []
+    separator = f"+-{'-' * max_length_key}-+-{'-' * max_length_value}-+"
+    table.append(separator)
+    table.append(f"| {'Library'.ljust(max_length_key)} | {'Version'.ljust(max_length_value)} |")
+    table.append(f"+={'=' * max_length_key}=+={'=' * max_length_value}=+")
+    for library, link in dict_table_entries.items():
+        table.append(f"| {library.ljust(max_length_key)} | {link.ljust(max_length_value)} |")
+        table.append(separator)
+
+    return table
+
+
+def get_release_branches_in_metapackage():
+    """Retrieve the release branches in the PyAnsys metapackage."""
+    import github
+
+    # Get the PyAnsys metapackage repository
+    g = github.Github(os.getenv("GITHUB_TOKEN", None))
+    github_repo = g.get_repo("ansys/pyansys")
+
+    # Get the branches
+    branches = github_repo.get_branches()
+
+    # Get the branches that are release branches + main
+    release_branches = []
+    versions = []
+    for branch in branches:
+        if branch.name.startswith("release"):
+            release_branches.append(branch.name)
+            versions.append(branch.name.split("/")[-1])
+
+    # Sort the release branches and versions: main + from newest to oldest
+    release_branches.reverse()
+    versions.reverse()
+    release_branches = ["main"] + release_branches
+    versions = ["dev"] + versions
+
+    return release_branches, versions
+
+
+# -------------------------------------------------------------------------
+# Execute the previous functions to generate the package_versions directory
+# -------------------------------------------------------------------------
+
+branches, versions = get_release_branches_in_metapackage()
+generate_rst_files(
+    versions,
+    {version: build_versions_table(branch) for version, branch in zip(versions, branches)},
+)
+
+###########################################################################

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -14,6 +14,7 @@ it is now a collection of many Python packages for using Ansys products through 
    api
    examples
    supported_versions
+   package_versions/index
    tools/index
 
 .. grid:: 3

--- a/doc/source/package_versions/.gitignore
+++ b/doc/source/package_versions/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,8 @@ all = [
 doc = [
     "Sphinx==8.0.2",
     "ansys-sphinx-theme==1.0.8",
+    "Jinja2 ==3.1.4",
+    "PyGithub==2.4.0",
     "sphinx-copybutton==0.5.2",
     "sphinx-design==0.6.1",
     "sphinxcontrib-mermaid==0.9.2",


### PR DESCRIPTION
Closes #677 

Generated local docs can be found here: 
[local_build.zip](https://github.com/user-attachments/files/16960256/local_build.zip)

I would appreciate your feedback @ansys/pyansys-core - this was a request coming from ACE. @MaxJPRey is aware.

Screenshots: 

Index page
![image](https://github.com/user-attachments/assets/7358133e-c283-457c-abf5-c022adea58f9)

Example of package listing
![image](https://github.com/user-attachments/assets/bc8bdf46-2b5f-475c-9d6f-4ae72a3150dc)


Logic is not pretty, but effective. I had to go with the raw Jinja2 dependency because of issues with sphinx-jinja.