### PR TITLE
fix: search.json location

### DIFF
--- a/index.html
+++ b/index.html
@@ -992,7 +992,7 @@ Shared Components</div>
 <script>
 // Passing the search options to the search.js file
 const SEARCH_OPTIONS = JSON.parse('{"ignoreLocation": true, "keys": ["title", "text"], "limit": 10, "min_chars_for_search": 2, "threshold": 0.5}');
-const SEARCH_FILE = "_static/search.json";
+const SEARCH_FILE = "version/dev/_static/search.json";
 </script>
 
 


### PR DESCRIPTION
Ensures the `search.json` is fetched from the right location.