### PR TITLE
feat: migrating linting/formatting exclusively to rust

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ repos:
   rev: v0.7.3
   hooks:
     - id: ruff
-      args: [ --fix ]
     - id: ruff-format
 
 - repo: https://github.com/codespell-project/codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,11 @@
 repos:
 
-- repo: https://github.com/psf/black
-  rev: 24.10.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.7.3
   hooks:
-  - id: black
-
-- repo: https://github.com/pycqa/isort
-  rev: 5.13.2
-  hooks:
-  - id: isort
-
-- repo: https://github.com/PyCQA/flake8
-  rev: 7.1.1
-  hooks:
-  - id: flake8
+    - id: ruff
+      args: [ --fix ]
+    - id: ruff-format
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.3.0
@@ -43,7 +35,7 @@ repos:
     - id: check-github-workflows
 
 - repo: https://github.com/ansys/pre-commit-hooks
-  rev: v0.4.4
+  rev: v0.4.3
   hooks:
   - id: add-license-headers
     args:

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 PyAnsys metapackage
 ===================
-|pyansys| |python| |pypi| |downloads| |GH-CI| |MIT| |black| |pre-commit|
+|pyansys| |python| |pypi| |downloads| |GH-CI| |MIT| |Ruff| |pre-commit|
 
 .. |pyansys| image:: https://img.shields.io/badge/Py-Ansys-ffc107.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABDklEQVQ4jWNgoDfg5mD8vE7q/3bpVyskbW0sMRUwofHD7Dh5OBkZGBgW7/3W2tZpa2tLQEOyOzeEsfumlK2tbVpaGj4N6jIs1lpsDAwMJ278sveMY2BgCA0NFRISwqkhyQ1q/Nyd3zg4OBgYGNjZ2ePi4rB5loGBhZnhxTLJ/9ulv26Q4uVk1NXV/f///////69du4Zdg78lx//t0v+3S88rFISInD59GqIH2esIJ8G9O2/XVwhjzpw5EAam1xkkBJn/bJX+v1365hxxuCAfH9+3b9/+////48cPuNehNsS7cDEzMTAwMMzb+Q2u4dOnT2vWrMHu9ZtzxP9vl/69RVpCkBlZ3N7enoDXBwEAAA+YYitOilMVAAAAAElFTkSuQmCC
    :target: https://docs.pyansys.com/
@@ -26,9 +26,9 @@ PyAnsys metapackage
    :target: https://opensource.org/licenses/MIT
    :alt: MIT
 
-.. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg?style=flat
-   :target: https://github.com/psf/black
-   :alt: Black
+.. |Ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+   :target: https://github.com/astral-sh/ruff
+   :alt: Ruff
 
 .. |pre-commit| image:: https://results.pre-commit.ci/badge/github/pyansys/pyansys/main.svg
    :target: https://results.pre-commit.ci/latest/github/pyansys/pyansys/main

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -46,7 +46,7 @@ metapackage release.
    {%- endfor %}
 """
 
-TMP_FILE = "tmp_pyproject.toml"
+TMP_FILE = Path("tmp_pyproject.toml")
 
 LaTeXBuilder.supported_image_types = [
     "image/png",
@@ -183,8 +183,7 @@ def generate_rst_files(versions: list[str], tables: dict[str, list[str]]):
         output_filename = GENERATED_DIR / f"version_{version}.rst"
 
         # Write the rendered content to the file
-        with Path.open(output_filename, "w") as file:
-            file.write(rendered_content)
+        output_filename.write_text(rendered_content, encoding="utf-8")
 
     # Generate the index.rst file
     index_template = jinja_env.from_string(INDEX_TEMPLATE)
@@ -192,8 +191,7 @@ def generate_rst_files(versions: list[str], tables: dict[str, list[str]]):
 
     # Write the rendered content to the file
     output_filename = GENERATED_DIR / "index.rst"
-    with Path.open(output_filename, "w") as file:
-        file.write(rendered_index)
+    output_filename.write_text(rendered_index, encoding="utf-8")
 
 
 def get_documentation_link_from_pypi(library: str, version: str) -> str:
@@ -254,7 +252,7 @@ def build_versions_table(branch: str) -> list[str]:
     """Build the versions table for the PyAnsys libraries."""
     # Download the pyproject.toml file
     resp = requests.get(f"https://raw.githubusercontent.com/ansys/pyansys/{branch}/pyproject.toml")
-    with Path.open("tmp_pyproject.toml", "wb") as file:
+    with TMP_FILE.open("wb") as file:
         file.write(resp.content)
 
     # Load the pyproject.toml file using TOML parser
@@ -290,7 +288,7 @@ def build_versions_table(branch: str) -> list[str]:
         ]
 
     # Delete the temporary file
-    Path.unlink(TMP_FILE)
+    TMP_FILE.unlink()
 
     # Build the table
     table = []

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,7 +10,11 @@ from sphinx.builders.latex import LaTeXBuilder
 
 from pyansys import __version__ as pyansys_version
 
-LaTeXBuilder.supported_image_types = ["image/png", "image/pdf", "image/svg+xml"]  # noqa: E501
+LaTeXBuilder.supported_image_types = [
+    "image/png",
+    "image/pdf",
+    "image/svg+xml",
+]  # noqa: E501
 
 project = "pyansys"
 copyright = f"(c) {datetime.now().year} ANSYS, Inc. All rights reserved"
@@ -235,7 +239,9 @@ def pyansys_multiversion_docs_link(docs_link: str, version: str) -> str:
 
         # Attempt to access the documentation for the specific version
         try:
-            resp = requests.get(f"{tmp_link}/version/{major_minor_version}/index.html")
+            resp = requests.get(
+                f"{tmp_link}/version/{major_minor_version}/index.html"
+            )
             if resp.status_code == 200:
                 return f"{tmp_link}/version/{major_minor_version}"
         except requests.exceptions.RequestException:
@@ -253,7 +259,9 @@ def build_versions_table(branch: str) -> list[str]:
     TMP_FILE = "tmp_pyproject.toml"
 
     # Download the pyproject.toml file
-    resp = requests.get(f"https://raw.githubusercontent.com/ansys/pyansys/{branch}/pyproject.toml")
+    resp = requests.get(
+        f"https://raw.githubusercontent.com/ansys/pyansys/{branch}/pyproject.toml"
+    )
     with open("tmp_pyproject.toml", "wb") as f:
         f.write(resp.content)
 
@@ -264,7 +272,9 @@ def build_versions_table(branch: str) -> list[str]:
     # load the PyAnsys library versions
     list_pyansys_libraries: list[str] = []
     if "poetry" in pyproject_toml["tool"]:  # Assume poetry
-        for key, val in pyproject_toml["tool"]["poetry"]["dependencies"].items():
+        for key, val in pyproject_toml["tool"]["poetry"][
+            "dependencies"
+        ].items():
             # Ignore some libraries
             if key in ["python", "importlib-metadata", "Sphinx"]:
                 continue
@@ -282,11 +292,15 @@ def build_versions_table(branch: str) -> list[str]:
                 continue
     else:  # Assume flit
         list_pyansys_libraries += pyproject_toml["project"]["dependencies"]
-        list_pyansys_libraries += pyproject_toml["project"]["optional-dependencies"]["all"]
+        list_pyansys_libraries += pyproject_toml["project"][
+            "optional-dependencies"
+        ]["all"]
 
         # Ignore some libraries: in this case, only importlib-metadata
         list_pyansys_libraries = [
-            entry for entry in list_pyansys_libraries if not entry.startswith("importlib-metadata")
+            entry
+            for entry in list_pyansys_libraries
+            if not entry.startswith("importlib-metadata")
         ]
 
     # Delete the temporary file
@@ -318,10 +332,14 @@ def build_versions_table(branch: str) -> list[str]:
     table = []
     separator = f"+-{'-' * libcol_size}-+-{'-' * vercol_size}-+"
     table.append(separator)
-    table.append(f"| {'Library'.ljust(libcol_size)} | {'Version'.ljust(vercol_size)} |")
+    table.append(
+        f"| {'Library'.ljust(libcol_size)} | {'Version'.ljust(vercol_size)} |"
+    )
     table.append(f"+={'=' * libcol_size}=+={'=' * vercol_size}=+")
     for library, entry in dict_table_entries.items():
-        table.append(f"| {entry[0].ljust(libcol_size)} | {entry[1].ljust(vercol_size)} |")
+        table.append(
+            f"| {entry[0].ljust(libcol_size)} | {entry[1].ljust(vercol_size)} |"
+        )
         table.append(separator)
 
     return table
@@ -380,7 +398,9 @@ def resize_with_background(input_image_path, output_image_path, target_size):
     from PIL import Image
 
     # Open the input image
-    img = Image.open(input_image_path).convert("RGBA")  # Ensure the image has an alpha channel
+    img = Image.open(input_image_path).convert(
+        "RGBA"
+    )  # Ensure the image has an alpha channel
 
     # Resize the image while maintaining aspect ratio
     img.thumbnail(target_size, Image.LANCZOS)
@@ -396,7 +416,9 @@ def resize_with_background(input_image_path, output_image_path, target_size):
     offset = ((bg_w - img_w) // 2, (bg_h - img_h) // 2)
 
     # Paste the resized image onto the white background
-    background.paste(img, offset, mask=img)  # Use the image's transparency as a mask
+    background.paste(
+        img, offset, mask=img
+    )  # Use the image's transparency as a mask
 
     # Convert the image to RGB to remove the alpha channel (no transparency)
     background = background.convert("RGB")
@@ -438,7 +460,10 @@ def package_versions_table(app: sphinx.application.Sphinx):
     branches, versions = get_release_branches_in_metapackage()
     generate_rst_files(
         versions,
-        {version: build_versions_table(branch) for version, branch in zip(versions, branches)},
+        {
+            version: build_versions_table(branch)
+            for version, branch in zip(versions, branches)
+        },
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,11 +110,5 @@ Documentation = "https://docs.pyansys.com"
 [tool.flit.module]
 name = "pyansys"
 
-[tool.black]
-line-length = 100
-
-[tool.isort]
-profile = "black"
-force_sort_within_sections = true
-line_length = 100
-src_paths = ["doc", "src"]
+[tool.ruff]
+line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,4 +111,36 @@ Documentation = "https://docs.pyansys.com"
 name = "pyansys"
 
 [tool.ruff]
-line-length = 79
+line-length = 100
+fix = true
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+docstring-code-format = true
+docstring-code-line-length = "dynamic"
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle, see https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+    "D",    # pydocstyle, see https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "F",    # pyflakes, see https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "I",    # isort, see https://docs.astral.sh/ruff/rules/#isort-i
+    "N",    # pep8-naming, see https://docs.astral.sh/ruff/rules/#pep8-naming-n
+    "PTH",  # flake8-use-pathlib, https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+    "TD",   # flake8-todos, https://docs.astral.sh/ruff/rules/#flake8-todos-td
+]
+ignore = [
+    "TD002", # Missing author in TODOs comment
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore `F401` (import violations) in all `__init__.py` files.
+"__init__.py" = ["F401"]
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+force-sort-within-sections = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,6 @@ docstring-code-line-length = "dynamic"
 [tool.ruff.lint]
 select = [
     "E",    # pycodestyle, see https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
-    "D",    # pydocstyle, see https://docs.astral.sh/ruff/rules/#pydocstyle-d
     "F",    # pyflakes, see https://docs.astral.sh/ruff/rules/#pyflakes-f
     "I",    # isort, see https://docs.astral.sh/ruff/rules/#isort-i
     "N",    # pep8-naming, see https://docs.astral.sh/ruff/rules/#pep8-naming-n
@@ -136,10 +135,6 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
-
-[tool.ruff.lint.per-file-ignores]
-# Ignore `F401` (import violations) in all `__init__.py` files.
-"__init__.py" = ["F401"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/pyansys/__init__.py
+++ b/src/pyansys/__init__.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 """PyAnsys general package __init__ file."""
+
 import importlib.metadata as importlib_metadata
 
 # Read from the pyproject.toml

--- a/tools/catsitemap.py
+++ b/tools/catsitemap.py
@@ -103,7 +103,7 @@ def generate_sitemap_index(project_names: list, dest_path: Path) -> None:
 
 if __name__ == "__main__":
     # Create path
-    folder_path = Path(".") / "sitemaps"
+    folder_path = Path() / "sitemaps"
     folder_path.mkdir(parents=True, exist_ok=True)
 
     # Get actual valid URLS and corresponding project names

--- a/tools/links.py
+++ b/tools/links.py
@@ -140,7 +140,9 @@ def search_and_replace(link: str, new_link: str):
                 with open(file_path, "w") as f:
                     f.write(new_content)
 
-                print(f"Replaced '{link}' with '{new_link}' in file: {file_path}")  # noqa: E501
+                print(
+                    f"Replaced '{link}' with '{new_link}' in file: {file_path}"
+                )  # noqa: E501
 
 
 def released_docs():
@@ -166,7 +168,9 @@ def released_docs():
 
         if major is None and minor is None:
             # No match found for the link... throw message
-            print(f"Error retrieving minor/major version of {key}... Skipping.")  # noqa: E501
+            print(
+                f"Error retrieving minor/major version of {key}... Skipping."
+            )  # noqa: E501
             continue
 
         # Define the new link

--- a/tools/links.py
+++ b/tools/links.py
@@ -11,7 +11,7 @@ Usage is very simple. Just run the script.
 from pathlib import Path
 import re
 
-ROOT_DIR = Path(Path(Path.resolve(Path(__file__)).parent).parent)
+ROOT_DIR = Path(__file__).parent.parent
 """Root directory of the project relative to this file."""
 
 PYPROJECT_TOML_FILE = ROOT_DIR / "pyproject.toml"
@@ -98,7 +98,7 @@ def retrieve_major_minor(package: str):
         The major and minor versions of the package.
 
     """
-    with Path.open(PYPROJECT_TOML_FILE, "r") as file:
+    with PYPROJECT_TOML_FILE.open("r") as file:
         content = file.read()
         pattern = r"\b" + re.escape(package) + r"==(\d+)\.(\d+)"
         match = re.search(pattern, content)
@@ -122,7 +122,7 @@ def search_and_replace(link: str, new_link: str):
         The link to replace the existing one.
     """
     # Traverse the docs directory
-    for root, _, files in Path.walk(DOCS_DIRECTORY):
+    for root, _, files in DOCS_DIRECTORY.walk():
         # Skip the _static subdirectory
         if "_static" in root.parts:
             continue
@@ -130,15 +130,12 @@ def search_and_replace(link: str, new_link: str):
         # Process the files
         for file in files:
             file_path = root / file
-            with Path.open(file_path, "r") as file:
-                content = file.read()
+            content = file_path.read_text(encoding="utf-8")
 
             # Search for the link in the content, replace and save
             if link in content:
                 new_content = content.replace(link, new_link)
-
-                with Path.open(file_path, "w") as file:
-                    file.write(new_content)
+                file_path.write_text(new_content, "utf-8")
 
                 print(f"Replaced '{link}' with '{new_link}' in file: {file_path}")  # noqa: E501
 

--- a/tools/links.py
+++ b/tools/links.py
@@ -8,16 +8,16 @@ Usage is very simple. Just run the script.
     python links.py
 """
 
-import os
+from pathlib import Path
 import re
 
-ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ROOT_DIR = Path(Path(Path.resolve(Path(__file__)).parent).parent)
 """Root directory of the project relative to this file."""
 
-PYPROJECT_TOML_FILE = os.path.join(ROOT_DIR, "pyproject.toml")
+PYPROJECT_TOML_FILE = ROOT_DIR / "pyproject.toml"
 """Path to pyproject.toml file."""
 
-DOCS_DIRECTORY = os.path.join(ROOT_DIR, "doc", "source")
+DOCS_DIRECTORY = ROOT_DIR / "doc" / "source"
 """Path to the documentation source directory"""
 
 LINKS = {
@@ -98,7 +98,7 @@ def retrieve_major_minor(package: str):
         The major and minor versions of the package.
 
     """
-    with open(PYPROJECT_TOML_FILE, "r") as file:
+    with Path.open(PYPROJECT_TOML_FILE, "r") as file:
         content = file.read()
         pattern = r"\b" + re.escape(package) + r"==(\d+)\.(\d+)"
         match = re.search(pattern, content)
@@ -122,27 +122,25 @@ def search_and_replace(link: str, new_link: str):
         The link to replace the existing one.
     """
     # Traverse the docs directory
-    for root, _, files in os.walk(DOCS_DIRECTORY):
+    for root, _, files in Path.walk(DOCS_DIRECTORY):
         # Skip the _static subdirectory
-        if "_static" in root.split(os.sep):
+        if "_static" in root.parts:
             continue
 
         # Process the files
         for file in files:
-            file_path = os.path.join(root, file)
-            with open(file_path, "r") as f:
-                content = f.read()
+            file_path = root / file
+            with Path.open(file_path, "r") as file:
+                content = file.read()
 
             # Search for the link in the content, replace and save
             if link in content:
                 new_content = content.replace(link, new_link)
 
-                with open(file_path, "w") as f:
-                    f.write(new_content)
+                with Path.open(file_path, "w") as file:
+                    file.write(new_content)
 
-                print(
-                    f"Replaced '{link}' with '{new_link}' in file: {file_path}"
-                )  # noqa: E501
+                print(f"Replaced '{link}' with '{new_link}' in file: {file_path}")  # noqa: E501
 
 
 def released_docs():
@@ -168,9 +166,7 @@ def released_docs():
 
         if major is None and minor is None:
             # No match found for the link... throw message
-            print(
-                f"Error retrieving minor/major version of {key}... Skipping."
-            )  # noqa: E501
+            print(f"Error retrieving minor/major version of {key}... Skipping.")  # noqa: E501
             continue
 
         # Define the new link

--- a/tools/milestone.py
+++ b/tools/milestone.py
@@ -78,9 +78,7 @@ g = github.Github(TOKEN)
 repo = g.get_repo(REPOSITORY)
 
 # Get its last release - assuming semantic versioning (i.e. v0.1.0)
-major, minor, *_ = (
-    repo.get_latest_release().tag_name.replace("v", "").split(".")
-)  # noqa: E501
+major, minor, *_ = repo.get_latest_release().tag_name.replace("v", "").split(".")  # noqa: E501
 next_release = f"v{major}.{int(minor)+1}.0"
 
 # Get its available milestones
@@ -115,6 +113,4 @@ official Ansys Release, please close and delete this milestone."""
 
     print(f"Milestone was created at {REPOSITORY} with name {next_release}!")
 else:
-    print(
-        f"Milestone was already available at {REPOSITORY}... Skipping creation!"
-    )  # noqa: 501
+    print(f"Milestone was already available at {REPOSITORY}... Skipping creation!")  # noqa: 501

--- a/tools/milestone.py
+++ b/tools/milestone.py
@@ -78,7 +78,9 @@ g = github.Github(TOKEN)
 repo = g.get_repo(REPOSITORY)
 
 # Get its last release - assuming semantic versioning (i.e. v0.1.0)
-major, minor, *_ = repo.get_latest_release().tag_name.replace("v", "").split(".")  # noqa: E501
+major, minor, *_ = (
+    repo.get_latest_release().tag_name.replace("v", "").split(".")
+)  # noqa: E501
 next_release = f"v{major}.{int(minor)+1}.0"
 
 # Get its available milestones
@@ -113,4 +115,6 @@ official Ansys Release, please close and delete this milestone."""
 
     print(f"Milestone was created at {REPOSITORY} with name {next_release}!")
 else:
-    print(f"Milestone was already available at {REPOSITORY}... Skipping creation!")  # noqa: 501
+    print(
+        f"Milestone was already available at {REPOSITORY}... Skipping creation!"
+    )  # noqa: 501


### PR DESCRIPTION
This PR fixes [issue #746](https://github.com/ansys/pyansys/issues/746). The following files were edited for migration of linting/formatting within the ansys/pyansys repo to Ruff:
1. pyproject.toml
2. .pre-commit-config.yaml
3. README.rst

**I also trialed the current ruff configuration for pre-commit locally before submitting this pull request. The reviewer should check the re-formatted files to decide if we need to customize a couple of options prior to merging, or not.**