### PR TITLE
feat: added cron job to update-gh-pages workflow

### DIFF
--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - "*"
   schedule:
-    - cron: "* * */14 * *"
+    - cron: "* 3 * * 5"
 
 env:
   MAIN_PYTHON_VERSION: '3.12'

--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -6,6 +6,8 @@ on:
   push:
     tags:
       - "*"
+  schedule:
+    - cron: "* * */14 * *"
 
 env:
   MAIN_PYTHON_VERSION: '3.12'


### PR DESCRIPTION
This pull request fix #752. It adds a scheduled cron to the update-gh-pages workflow. The interval is currently set to once every two weeks.