### PR TITLE
fix: .flake8 is no longer required

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-
-[flake8]
-max-line-length = 100


### PR DESCRIPTION
Continuation of #750. Removes unnecessary `.flake8` file.