### PR TITLE
fix: filtering of families and tags

### DIFF
--- a/doc/source/_static/js/landing_page.js
+++ b/doc/source/_static/js/landing_page.js
@@ -117,7 +117,7 @@ function handleFamilySelection() {
     document.querySelectorAll(
       '#product-families-list input[type="checkbox"]:checked',
     ),
-  ).map((checkbox) => checkbox.id.replace("family-", "").toLowerCase());
+  ).map((checkbox) => checkbox.id.replace("family-", "").replace("\\ ", "-").toLowerCase());
 
   console.log("Selected families:", selectedFamilies);
 
@@ -125,6 +125,7 @@ function handleFamilySelection() {
 
   projectCards.forEach((card) => {
     const family = card.getAttribute("data-family").toLowerCase();
+    console.log("Family:", family);
     card.style.display =
       selectedFamilies.length === 0 || selectedFamilies.includes(family)
         ? "flex"
@@ -137,7 +138,7 @@ function handleTagSelection() {
     document.querySelectorAll(
       '#product-tags-list input[type="checkbox"]:checked',
     ),
-  ).map((checkbox) => checkbox.id.replace("tag-", "").toLowerCase());
+  ).map((checkbox) => checkbox.id.replace("tag-", "").replace("\\ ", "-").toLowerCase());
 
   console.log("Selected tags:", selectedTags);
 

--- a/doc/source/_static/js/landing_page.js
+++ b/doc/source/_static/js/landing_page.js
@@ -117,7 +117,9 @@ function handleFamilySelection() {
     document.querySelectorAll(
       '#product-families-list input[type="checkbox"]:checked',
     ),
-  ).map((checkbox) => checkbox.id.replace("family-", "").replace("\\ ", "-").toLowerCase());
+  ).map((checkbox) =>
+    checkbox.id.replace("family-", "").replace("\\ ", "-").toLowerCase(),
+  );
 
   console.log("Selected families:", selectedFamilies);
 
@@ -138,7 +140,9 @@ function handleTagSelection() {
     document.querySelectorAll(
       '#product-tags-list input[type="checkbox"]:checked',
     ),
-  ).map((checkbox) => checkbox.id.replace("tag-", "").replace("\\ ", "-").toLowerCase());
+  ).map((checkbox) =>
+    checkbox.id.replace("tag-", "").replace("\\ ", "-").toLowerCase(),
+  );
 
   console.log("Selected tags:", selectedTags);
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -27,10 +27,12 @@ it is now a collection of many Python packages for using Ansys products through 
             {% set family = metadata.get('family', 'other') | lower | replace(' ', '-') %}
             {% set tags = metadata.get('tags', 'other') | lower %}
 
-            <div class="project-card sd-shadow-sm sd-card-hover" data-family="{{ family }}" data-tags="{{ tags }}">
+            <div class="project-card sd-card sd-shadow-sm sd-card-hover" data-family="{{ family }}" data-tags="{{ tags }}">
                 <img class="project-thumbnail" src="{{ metadata['thumbnail'] }}" />
-                <p class="project-title"> {{ metadata['name'] }} </p>
-                <p class="project-description"> {{ metadata['description'] }} </p>
+                <div class="sd-card-body">
+                    <p class="sd-card-title sd-font-weight-bold"> {{ metadata['name'] }} </p>
+                    <p class="sd-card-body-text"> {{ metadata['description'] }} </p>
+                </div>
             </div>
 
             {% endfor %}


### PR DESCRIPTION
Continuation of #796. 

It ensures that 

- [x] Families and tags with two names are properly handled
- [x] Dark and light theme works as expected