### PR TITLE
Update PyACP to 0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "ansys-acp-core==0.1rc1",
+    "ansys-acp-core==0.1.0",
     "ansys-additive-core==0.18.1",
     "ansys-additive-widgets==0.2.1",
     "ansys-conceptev-core==0.8",


### PR DESCRIPTION
Update PyACP from the release candidate to full release version.

Looking at the last dependabot run, I think this wouldn't update automatically. Maybe because the previous version was `0.1rc1`, not `0.1.0rc1`.