### PR TITLE
fix(docs): pyedb examples URL

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -194,7 +194,7 @@ projects:
     documentation:
       base: https://edb.docs.pyansys.com/version/stable
       user_guide: https://edb.docs.pyansys.com/version/stable/user_guide/index.html
-      examples: https://edb.docs.pyansys.com/version/stable/examples/index.html
+      examples: https://examples.aedt.docs.pyansys.com/version/dev/index.html
       api: https://edb.docs.pyansys.com/version/stable/api/index.html
 
   pyedb-core:


### PR DESCRIPTION
Pyedb examples have been migrated to the pyaedt-example repo, see https://examples.aedt.docs.pyansys.com/version/dev/examples/high_frequency/radiofrequency_mmwave/index.html