### PR TITLE
Add PyFluent to both Fluids and Meshing families

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -230,7 +230,7 @@ projects:
     repository: https://github.com/ansys/pyfluent
     description:  Pythonic interface to Ansys Fluent
     thumbnail: _static/thumbnails/pyfluent.png
-    family: Fluids
+    family: [Fluids, Meshing]
     tags: [Flagship, Visualization]
     icon: _static/icons/fluids.svg
     documentation:


### PR DESCRIPTION
Is this going to work? Ideally, PyFluent would show up for both Fluids and Meshing filters, as it is used for both