### PR TITLE
ci(docs): update the search path and root url on landing index page

### DIFF
--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -48,6 +48,8 @@ jobs:
         sed -i 's/href="\([^:"]*\)"/href="version\/dev\/\1"/g' index.html
         sed -i 's/src="\([^:"]*\)"/src="version\/dev\/\1"/g' index.html
         sed -i 's/action="search.html"/action="version\/dev\/\search.html"/g' index.html
+        sed -i 's|<html lang="en" data-content_root="./" >|<html lang="en" data-content_root="./version/dev/" >|g' index.html
+        sed -i '/const ADVANCE_SEARCH_PATH = "search.html";/s|search.html|version/dev/search.html|' index.html
         # Update JS variables pointing to static values
         sed -i 's|const SEARCH_FILE = ".*_static/search.json";|const SEARCH_FILE = "version/dev/_static/search.json";|g' index.html
         sed -i 's|const PROJECTS_FILE = "_static/projects.json"|const PROJECTS_FILE = "version/dev/_static/projects.json"|' index.html


### PR DESCRIPTION
<img width="970" alt="Screenshot 2025-06-23 at 09 23 04" src="https://github.com/user-attachments/assets/2a7bb514-e6bd-47e5-bea3-275d8b51602a" />
Search results in the landing index page is not working. It is working with ansys actions and add all the bash commands here as well. 