### PR TITLE
build: update ansys-edb-core version for new SP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,4 +147,3 @@ force-sort-within-sections = true
 
 
 
-


### PR DESCRIPTION
Previous version `v0.2.3` contained an issue which caused instability in `pyedb`. That should be patched in `v0.2.4`.

@RobPasMue If possible, this version should be the default version to be used to work with the new SP. 