### PR TITLE
test: compatibility of ansys-dpf-core `0.15.0` with other 252 packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "ansys-additive-core==0.20.0",
     "ansys-conceptev-core==0.9.4",
     "ansys-dpf-composites==0.7.0",
-    "ansys-dpf-core==0.14.1",
+    "ansys-dpf-core==0.15.0",
     "ansys-dpf-post==0.10.0",
     "ansys-dyna-core==0.9.0",
     "ansys-dynamicreporting-core==0.10.1",


### PR DESCRIPTION
> [!WARNING]  
> Do not merge. Opened just to see if `ansys-dpf-core` 0.15.0 is compatible with other pyansys package versions included in metapackage `2025.2`.