### PR TITLE
test: compatibility of ansys-dpf-core `0.15.0` with other 251 packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "ansys-additive-widgets==0.2.1",
     "ansys-conceptev-core==0.8",
     "ansys-dpf-composites==0.6.2",
-    "ansys-dpf-core==0.13.4",
+    "ansys-dpf-core==0.15.0",
     "ansys-dpf-post==0.9.2",
     "ansys-dyna-core==0.7.1",
     "ansys-dynamicreporting-core==0.9.0",


### PR DESCRIPTION
> [!WARNING]  
> Do not merge. Opened just to see if `ansys-dpf-core` 0.15.0 is compatible with other pyansys package versions included in metapackage `2025.1`.