### PR TITLE
fix: reinstate pydynamic reporting

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -18,9 +18,8 @@ env:
   PACKAGE_NAMESPACE: pyansys
   MAIN_PYTHON_VERSION: '3.11'
   DOCUMENTATION_CNAME: "docs.pyansys.com"
-  # attrs,referencing,jeepney - This has MIT license but fails the check
   # paramiko,psycopg,psycopg-binary - LGPL licenses, being used by ansys-dynamicreporting-core and ansys-turbogrid-core
-  LICENSE_WHITELISTING: "attrs,referencing,jeepney,paramiko,psycopg,psycopg-binary"
+  LICENSE_WHITELISTING: "paramiko,psycopg,psycopg-binary"
 
 jobs:
   check-vulnerabilities:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,7 @@ dependencies = [
     "ansys-dpf-core==0.16.0",
     "ansys-dpf-post==0.12.0",
     "ansys-dyna-core==0.11.0",
-    # TODO: To be reinstated once PyDynamicReporting supports
-    # Python 3.13 and Numpy 2.X
-    # "ansys-dynamicreporting-core==0.10.3; python_version<'3.13'",
+    "ansys-dynamicreporting-core==0.10.7",
     "ansys-edb-core==0.3.1",
     "ansys-fluent-core==0.38.1",
     "ansys-geometry-core==0.15.2",


### PR DESCRIPTION
Given that the package is now "compatible" with `numpy>=2.Y`, checking if this can be performed.
The compatibility being for python version above or equal to Python3.13 (see [here](https://github.com/ansys/pydynamicreporting/blob/main/pyproject.toml#L20-L21)) I'm not sure if we should add it back.

Close #1183 