### PR TITLE
docs: sphinx-autobuild for faster doc rendering

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -26,3 +26,10 @@ pdf:
 
 clean:
 	rm -rf $(BUILDDIR)
+
+# Run sphinx-autobuild to automatically rebuild the docs when changes are made
+autobuild:
+	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)/html" \
+		--ignore="$(SOURCEDIR)/_static/projects.json" \
+		--ignore="$(SOURCEDIR)/_static/blog_metadata.json" \
+		$(SPHINXOPTS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ doc = [
     "Jinja2>=3.1.6",
     "Pillow>=12.2.0",
     "PyGithub>=2.9.1",
+    "sphinx-autobuild>=2024.10.3",
     "sphinx-copybutton>=0.5.2",
     "sphinx-design>=0.6.1",
     "sphinxcontrib-mermaid>=2.0.2",


### PR DESCRIPTION
Use https://github.com/sphinx-doc/sphinx-autobuild to hot-reload while you are doing the changes and seeing them live in the browser (http://localhost:8000).