### PR TITLE
chore: drop Python 3.10 and 3.11 based on SPEC-0 and internal reqs

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
   PACKAGE_NAME: pyansys
   PACKAGE_NAMESPACE: pyansys
-  MAIN_PYTHON_VERSION: '3.11'
+  MAIN_PYTHON_VERSION: '3.14'
   DOCUMENTATION_CNAME: "docs.pyansys.com"
   # attrs,referencing,jeepney - This has MIT license but fails the check
   # paramiko,psycopg,psycopg-binary - LGPL licenses, being used by ansys-dynamicreporting-core and ansys-turbogrid-core
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
@@ -103,7 +103,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.12', '3.13', '3.14']
         extras-version: ['fluent-all', 'mapdl-all', 'tools']
 
     steps:
@@ -136,7 +136,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.12', '3.13', '3.14']
 
     steps:
       - name: Build wheelhouse and perform smoke test
@@ -240,7 +240,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           library-name: ${{ env.PACKAGE_NAME }}
-          additional-artifacts: 'all-deps-Linux-3.10 all-deps-Linux-3.11 all-deps-Linux-3.12 all-deps-Linux-3.13 all-deps-Linux-3.14 all-deps-Windows-3.10 all-deps-Windows-3.11 all-deps-Windows-3.12 all-deps-Windows-3.13 all-deps-Windows-3.14 all-deps-macOS-3.10 all-deps-macOS-3.11 all-deps-macOS-3.12 all-deps-macOS-3.13 all-deps-macOS-3.14'
+          additional-artifacts: 'all-deps-Linux-3.12 all-deps-Linux-3.13 all-deps-Linux-3.14 all-deps-Windows-3.12 all-deps-Windows-3.13 all-deps-Windows-3.14 all-deps-macOS-3.12 all-deps-macOS-3.13 all-deps-macOS-3.14'
           add-artifact-attestation-notes: true
           changelog-release-notes: true
 

--- a/README.rst
+++ b/README.rst
@@ -194,18 +194,18 @@ the ``pyansys`` metapackage is downloading the wheelhouse archive from the
 `Releases Page <https://github.com/ansys/pyansys/releases>`_ for your corresponding machine architecture.
 
 Each wheelhouse archive contains all the Python wheels necessary to install the ``pyansys`` metapackage from
-scratch on Windows, Linux, and MacOS from Python 3.10 to 3.14. You can install this on an isolated system with
+scratch on Windows, Linux, and MacOS from Python 3.12 to 3.14. You can install this on an isolated system with
 a fresh Python installation or on a virtual environment.
 
-For example, on Linux with Python 3.10, unzip the wheelhouse archive and install it with the following
+For example, on Linux with Python 3.12, unzip the wheelhouse archive and install it with the following
 commands:
 
 .. code:: bash
 
-    unzip pyansys-v2025.1.dev0-wheelhouse-Linux-3.10-core.zip wheelhouse
+    unzip pyansys-v2025.1.dev0-wheelhouse-Linux-3.12-core.zip wheelhouse
     pip install pyansys -f wheelhouse --no-index --upgrade --ignore-installed
 
-If you're on Windows with Python 3.10, unzip to a wheelhouse directory and then install using
+If you're on Windows with Python 3.12, unzip to a wheelhouse directory and then install using
 the same ``pip`` command as in the previous example.
 
 Consider installing using a `virtual environment <https://docs.python.org/3/library/venv.html>`_.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -215,7 +215,7 @@ def read_project_json():
 jinja_globals = {
     "LAST_RELEASE": get_last_metapackage_release(),
     "VERSION": version,
-    "SUPPORTED_PYTHON_VERSIONS": ["3.10", "3.11", "3.12", "3.13", "3.14"],
+    "SUPPORTED_PYTHON_VERSIONS": ["3.12", "3.13", "3.14"],
     "SUPPORTED_PLATFORMS": ["Windows", "macOS", "Linux"],
 }
 jinja_contexts = {

--- a/doc/source/getting-started/install.rst
+++ b/doc/source/getting-started/install.rst
@@ -125,7 +125,7 @@ Start by downloading the wheelhouse artifact for your platform:
 
     .. csv-table::
        :header-rows: 1
-       :widths: 16, 28, 28, 28, 28, 28
+       :widths: 16, 28, 28, 28
 
        :fas:`laptop` Platform,
        {%- for python in SUPPORTED_PYTHON_VERSIONS -%}

--- a/doc/source/getting-started/prerequisites.rst
+++ b/doc/source/getting-started/prerequisites.rst
@@ -38,8 +38,8 @@ after their initial release:
         Python 3.7  :done,   des1, 2018-06-27, 3y
         Python 3.8  :done,   des2, 2019-10-14, 3y
         Python 3.9  :done,   des3, 2020-10-05, 3y
-        Python 3.10 :active, des4, 2021-10-04, 3y
-        Python 3.11 :active, des5, 2022-10-24, 3y
+        Python 3.10 :done,   des4, 2021-10-04, 3y
+        Python 3.11 :done,   des5, 2022-10-24, 3y
         Python 3.12 :active, des6, 2023-10-02, 3y
         Python 3.13 :active, des7, 2024-10-01, 3y
         Python 3.14 :active, des8, 2025-10-07, 3y

--- a/doc/source/getting-started/prerequisites.rst
+++ b/doc/source/getting-started/prerequisites.rst
@@ -35,8 +35,6 @@ after their initial release:
         dateFormat YYYY-MM-DD
         axisFormat %Y-%m
 
-        Python 3.7  :done,   des1, 2018-06-27, 3y
-        Python 3.8  :done,   des2, 2019-10-14, 3y
         Python 3.9  :done,   des3, 2020-10-05, 3y
         Python 3.10 :done,   des4, 2021-10-04, 3y
         Python 3.11 :done,   des5, 2022-10-24, 3y

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "pyansys"
 version = "2025.1.dev0"
 description = "Pythonic interfaces to Ansys products"
 readme = "README.rst"
-requires-python = ">=3.10,<4"
+requires-python = ">=3.12,<4"
 license = { file = "LICENSE" }
 authors = [{ name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" }]
 maintainers = [{ name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" }]
@@ -18,8 +18,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",


### PR DESCRIPTION
Following drop of Python 3.10 internally and guidelines from SPEC-0, we can now drop support for 3.10 and 3.11 safely