### PR TITLE
docs: remove spans from footer social icons

### DIFF
--- a/doc/source/_templates/footer_left.html
+++ b/doc/source/_templates/footer_left.html
@@ -5,7 +5,7 @@
 
     <!-- Copyright notice -->
     <div class="footer-item"><br>
-        <p>© Copyright (c) 2025 ANSYS, Inc. All rights reserved.</p>
+        <p>© Copyright (c) 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved</p>
     </div>
 
 </div>

--- a/doc/source/_templates/footer_right.html
+++ b/doc/source/_templates/footer_right.html
@@ -3,10 +3,10 @@
   <!-- Social media icons -->
   <span>Connect with Ansys</span>
   <div class="social-icons">
-    <a href="https://www.youtube.com/user/ansysinc" target="_blank" rel="noopener" class="icon icon-youtube" aria-label="Youtube"><span class="sr-only">Youtube</span></a>
-    <a href="https://www.facebook.com/ansys" target="_blank" rel="noopener" class="icon icon-facebook" aria-label="Facebook"><span class="sr-only">Facebook</span></a>
-    <a href="https://www.linkedin.com/company/ansys-inc" target="_blank" rel="noopener" class="icon icon-linkedin" aria-label="Linkedin"><span class="sr-only">Linkedin</span></a>
-    <a href="https://github.com/ansys" target="_blank" rel="noopener" class="icon icon-github" aria-label="GitHub"><i class="fab fa-github"></i><span class="sr-only">GitHub</span></a>
+    <a href="https://www.youtube.com/user/ansysinc" target="_blank" rel="noopener" class="icon icon-youtube" aria-label="Youtube"></a>
+    <a href="https://www.facebook.com/ansys" target="_blank" rel="noopener" class="icon icon-facebook" aria-label="Facebook"></a>
+    <a href="https://www.linkedin.com/company/ansys-inc" target="_blank" rel="noopener" class="icon icon-linkedin" aria-label="Linkedin"></a>
+    <a href="https://github.com/ansys" target="_blank" rel="noopener" class="icon icon-github" aria-label="GitHub"><i class="fab fa-github"></i></a>
   </div>
 
 </div>

--- a/projects.yaml
+++ b/projects.yaml
@@ -631,7 +631,7 @@ projects:
     name: PyAEDT Antenna Toolkit
     description: Python wrapper for modeling antennas using Ansys Electronics Desktop (AEDT) via PyAEDT
     thumbnail: _static/thumbnails/intro.png
-    repository: https://github.com/ansys/pyaedt-antenna-toolkit
+    repository: https://github.com/ansys/pyaedt-toolkits-antenna
     families: [Electronics]
     tags: [Tools]
     icon: _static/icons/ansys-icon-light.svg


### PR DESCRIPTION
## Changes
- Removed `<span class="sr-only">` from Facebook, LinkedIn, and GitHub footer icons
- The `aria-label` attribute already present on each `<a>` tag provides equivalent screen-reader accessibility

## Root cause
Bootstrap 5 (used by pydata-sphinx-theme) deprecated `.sr-only` in favor of `.visually-hidden`. The class was never defined in the theme CSS, causing the hidden text to render as visible content.