### PR TITLE
Update ansys-dpf-composites to 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "ansys-chemkin-core==0.2.0",
     "ansys-cfx-core==0.3.0",
     "ansys-conceptev-core==0.11.1",
-    "ansys-dpf-composites==0.7.0",
+    "ansys-dpf-composites==0.8.0",
     "ansys-dpf-core==0.16.1",
     "ansys-dpf-post==0.12.0",
     "ansys-dyna-core==0.12.1",
@@ -161,4 +161,3 @@ convention = "numpy"
 [tool.ruff.lint.isort]
 combine-as-imports = true
 force-sort-within-sections = true
-


### PR DESCRIPTION
Update `ansys-dpf-composites` to version `0.8.0`, which is compatible
with the 2027R1 release.