### PR TITLE
build: cooldown config for PyAnsys packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,16 @@ updates:
     insecure-external-code-execution: allow
     schedule:
       interval: "daily"
+    cooldown:
+      # Specifically set to 0 for PyAnsys ecosystem related packages
+      default-days: 0
+      include:
+       - ansys-*
+       - pyansys-*
+       - pyaedt
+       - pyedb
+       - pygranta
+       - pytwin
     groups:
        deps:
           patterns:


### PR DESCRIPTION
As title says...

PyAnsys packages shouldn't be impacted by the default cooldown period imposed by dependabot